### PR TITLE
fixed spelling of 'sine' on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Ruby can perform any operation that a simple calculator can. Open up IRB (open y
 
 Enclosing an expression in parentheses `()` defines an order of operations, like you would [expect](http://en.wikipedia.org/wiki/Order_of_operations).
 
-* `98 + 59/13 * 8 * -5 = -62` 
+* `98 + 59/13 * 8 * -5 = -62`
 * `98 + (59/(13*8)) * -5 = 98`
 
 ## Division and Intro to Floats
@@ -36,14 +36,14 @@ There is another operator that is really useful in programming. It's the modulo,
 
 ## Math module
 
-Ruby has built-in methods for common math functions. The basic trigonometric and transcendental functions are available in the [Math module](http://ruby-doc.org/core-2.2.0/Math.html). This gives you access to mathematic tools such as square root, sin, cosine, and tangent via Ruby methods. To access these in your code simply refer to the module `Math` and call the method on the module. For example, to get the square root of 9 you'd write `Math.sqrt(9)`. [Read more about the Math module and the available methods.](http://ruby-doc.org/core-2.2.0/Math.html)
+Ruby has built-in methods for common math functions. The basic trigonometric and transcendental functions are available in the [Math module](http://ruby-doc.org/core-2.2.0/Math.html). This gives you access to mathematic tools such as square root, sine, cosine, and tangent via Ruby methods. To access these in your code simply refer to the module `Math` and call the method on the module. For example, to get the square root of 9 you'd write `Math.sqrt(9)`. [Read more about the Math module and the available methods.](http://ruby-doc.org/core-2.2.0/Math.html)
 
 ## Instructions
 
 Fork and clone this repo and open `lib/math.rb`. You'll find a bunch of empty methods that take numbers as arguments. Build the appropriate behavior for each of the following methods:
 - addition
 - subtraction
-- multiplication 
+- multiplication
 - division
 - modulo
 - square root


### PR DESCRIPTION
The readme file lists the trigonometric functions that are available but abbreviates sine to sin (which is the method name, not the mathematical process) while fully spelling out cosine and tangent. This pull request adds an 'e' to fix the spelling of sine.
